### PR TITLE
Add dev build of 2.35 from r-universe

### DIFF
--- a/.ci_support/linux_64_r_base4.3.yaml
+++ b/.ci_support/linux_64_r_base4.3.yaml
@@ -12,8 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_r_base4.4.yaml
+++ b/.ci_support/linux_64_r_base4.4.yaml
@@ -12,8 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_r_base4.3.yaml
+++ b/.ci_support/linux_aarch64_r_base4.3.yaml
@@ -16,8 +16,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_r_base4.4.yaml
+++ b/.ci_support/linux_aarch64_r_base4.4.yaml
@@ -16,8 +16,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_r_base4.3.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.3.yaml
@@ -12,8 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_r_base4.4.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.4.yaml
@@ -12,8 +12,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_r_base4.3.yaml
+++ b/.ci_support/osx_64_r_base4.3.yaml
@@ -14,8 +14,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_r_base4.4.yaml
+++ b/.ci_support/osx_64_r_base4.4.yaml
@@ -14,8 +14,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_r_base4.3.yaml
+++ b/.ci_support/osx_arm64_r_base4.3.yaml
@@ -14,8 +14,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_r_base4.4.yaml
+++ b/.ci_support/osx_arm64_r_base4.4.yaml
@@ -14,8 +14,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/win_64_r_base4.3.yaml
+++ b/.ci_support/win_64_r_base4.3.yaml
@@ -2,8 +2,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 m2w64_c_compiler:
 - gcc
 m2w64_c_compiler_version:

--- a/.ci_support/win_64_r_base4.4.yaml
+++ b/.ci_support/win_64_r_base4.4.yaml
@@ -2,8 +2,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-cran_mirror:
-- https://cran.r-project.org
 m2w64_c_compiler:
 - gcc
 m2w64_c_compiler_version:

--- a/recipe/conda_build_config.yml
+++ b/recipe/conda_build_config.yml
@@ -1,0 +1,2 @@
+channel_targets:
+  - conda-forge r-stanheaders_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.32.10" %}
+{% set version = "2.35.0.9000" %}
 {% set posix = 'm2-' if win else '' %}
 
 package:
@@ -6,15 +6,15 @@ package:
   version: {{ version|replace("-", "_") }}
 
 source:
-  url:
-    - {{ cran_mirror }}/src/contrib/StanHeaders_{{ version }}.tar.gz
-    - {{ cran_mirror }}/src/contrib/Archive/StanHeaders/StanHeaders_{{ version }}.tar.gz
-  sha256: c3125b8d7dc4c6b7082258b2fa6c9530c2e4714c89ffd08b8e72f4c9f4108582
+  url: https://stan-dev.r-universe.dev/src/contrib/StanHeaders_{{ version }}.tar.gz
+  ## note these are not stable and get periodically rebuilt: see https://github.com/r-universe-org/help/discussions/262
+  ## an official md5 checksum can be retrieved from: https://stan-dev.r-universe.dev/api/packages
+  sha256: 543ca25a96a3c7f8dff1086107da644a7176378df2820cf6d14be453e6125d3e
   patches:
     - sundials_noprofile.patch  # [win]
 
 build:
-  number: 1
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

A newer RStan and StanHeaders are available from https://stan-dev.r-universe.dev/builds. These will eventually be on CRAN, but due to the backwards compatibility policy there it may be quite some time.

Before being merged, this repository would need to create a `dev` branch off main and have this PR re-targeted there: https://conda-forge.org/docs/maintainer/knowledge_base/#pre-release-builds